### PR TITLE
Fix ley_numero extraction for bills ETL

### DIFF
--- a/src/etl/etl_bills.md
+++ b/src/etl/etl_bills.md
@@ -30,7 +30,7 @@ Esta es la **tabla principal o maestra** de los proyectos de ley. Cada fila repr
     * `origen`: Cámara donde se inició el proyecto.
     * `urgencia`: Nivel de urgencia actual (ej: "Suma", "Simple").
     * `resultado_final`: Estado final (ej: "Publicado", "Rechazado", "En tramitación").
-    * `ley_numero`: Número de ley asignado si fue aprobado y publicado.
+    * `ley_numero`: Identificador numérico `<Id>` del proyecto (utilizado como número de ley).
     * `ley_fecha_publicacion`: Fecha de publicación en el Diario Oficial.
 
 ### Tabla: `bill_authors`
@@ -109,6 +109,6 @@ La siguiente tabla detalla cómo cada campo del XML se mapea a una columna en la
 | `<CamaraOrigen>/<Nombre>` | `bills` | `origen` | Cámara donde se inició el proyecto (ej: "Cámara de Diputados"). |
 | `<UrgenciaActual>` | `bills` | `urgencia` | Tipo de urgencia que tiene el proyecto (ej: "Suma", "Simple"). |
 | `<Estado>` | `bills` | `resultado_final` | El estado actual del proyecto (ej: "En tramitación", "Publicado"). |
-| `<Ley>/<Numero>` | `bills` | `ley_numero` | El número de ley asignado si el proyecto fue publicado. |
+| `<Id>` | `bills` | `ley_numero` | Identificador del proyecto devuelto por la API. |
 | `<Ley>/<FechaPublicacion>` | `bills` | `ley_fecha_publicacion` | Fecha de publicación en el Diario Oficial. |
 | `<Autores>...<Diputado>/<Id>` | `bill_authors` | `mp_uid` | Se itera, se extrae el `diputadoid` y se busca el `mp_uid` para la inserción.|

--- a/src/etl/etl_bills.py
+++ b/src/etl/etl_bills.py
@@ -125,7 +125,9 @@ def fetch_bill_details(bill_id: str):
 
         details["resultado_final"] = root.findtext('.//v1:Estado', namespaces=NS)
 
-        details["ley_numero"] = root.findtext('.//v1:Ley/v1:Numero', namespaces=NS)
+        # Algunos proyectos no cuentan con la etiqueta <Ley>/<Numero>.
+        # Se utiliza <Id> como identificador numérico del proyecto.
+        details["ley_numero"] = root.findtext('.//v1:Id', namespaces=NS)
 
         ley_fecha_str = root.findtext('.//v1:Ley/v1:FechaPublicacion', namespaces=NS)
         details["ley_fecha_publicacion"] = ley_fecha_str.split('T')[0] if ley_fecha_str else None


### PR DESCRIPTION
## Summary
- Use `<Id>` value from API responses as `ley_numero`
- Document `ley_numero` as extracted from `<Id>`

## Testing
- `pytest`
- `python -m py_compile src/etl/etl_bills.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba53f406108329a6e7d3cb8c36c43b